### PR TITLE
Add inheritance to Node interfaces

### DIFF
--- a/src/FluentDOM/DOM/CdataSection.php
+++ b/src/FluentDOM/DOM/CdataSection.php
@@ -17,7 +17,7 @@ namespace FluentDOM\DOM {
    */
   class CdataSection
     extends \DOMCdataSection
-    implements Node, Node\ChildNode, Node\NonDocumentTypeChildNode {
+    implements Node\NonDocumentTypeChildNode {
 
     use Node\ChildNode\Implementation;
     use Node\NonDocumentTypeChildNode\Properties;

--- a/src/FluentDOM/DOM/Comment.php
+++ b/src/FluentDOM/DOM/Comment.php
@@ -17,7 +17,7 @@ namespace FluentDOM\DOM {
    */
   class Comment
     extends \DOMComment
-    implements Node, Node\ChildNode, Node\NonDocumentTypeChildNode  {
+    implements Node\NonDocumentTypeChildNode  {
 
     use Node\ChildNode\Implementation;
     use Node\NonDocumentTypeChildNode\Properties;

--- a/src/FluentDOM/DOM/Document.php
+++ b/src/FluentDOM/DOM/Document.php
@@ -25,7 +25,7 @@ namespace FluentDOM\DOM {
    * @property-read Element $firstElementChild
    * @property-read Element $lastElementChild
    */
-  class Document extends \DOMDocument implements Node, Node\ParentNode {
+  class Document extends \DOMDocument implements Node\ParentNode {
 
     use
       Node\ParentNode\Properties,

--- a/src/FluentDOM/DOM/DocumentFragment.php
+++ b/src/FluentDOM/DOM/DocumentFragment.php
@@ -27,8 +27,7 @@ namespace FluentDOM\DOM {
     implements
       \Countable,
       \IteratorAggregate,
-      Node,
-      Node\ParentNode {
+      Node {
 
     use
       /** @noinspection TraitsPropertiesConflictsInspection */

--- a/src/FluentDOM/DOM/Element.php
+++ b/src/FluentDOM/DOM/Element.php
@@ -32,8 +32,6 @@ namespace FluentDOM\DOM {
       \ArrayAccess,
       \Countable,
       \IteratorAggregate,
-      Node,
-      Node\ChildNode,
       Node\NonDocumentTypeChildNode,
       Node\ParentNode {
 

--- a/src/FluentDOM/DOM/Node/ChildNode.php
+++ b/src/FluentDOM/DOM/Node/ChildNode.php
@@ -2,7 +2,9 @@
 
 namespace FluentDOM\DOM\Node {
 
-  interface ChildNode {
+  use FluentDOM\DOM\Node;
+
+  interface ChildNode extends Node {
 
     public function remove():\DOMNode;
     public function before($nodes);

--- a/src/FluentDOM/DOM/Node/NonDocumentTypeChildNode.php
+++ b/src/FluentDOM/DOM/Node/NonDocumentTypeChildNode.php
@@ -9,7 +9,7 @@ namespace FluentDOM\DOM\Node {
    * @property Element $nextElementSibling
    * @property Element $previousElementSibling
    */
-  interface NonDocumentTypeChildNode {
+  interface NonDocumentTypeChildNode extends ChildNode {
 
   }
 }

--- a/src/FluentDOM/DOM/Node/ParentNode.php
+++ b/src/FluentDOM/DOM/Node/ParentNode.php
@@ -11,6 +11,7 @@
 namespace FluentDOM\DOM\Node {
 
   use FluentDOM\DOM\Element;
+  use FluentDOM\DOM\Node;
 
   /**
    * Interface ParentNode
@@ -18,7 +19,7 @@ namespace FluentDOM\DOM\Node {
    * @property-read Element $lastElementChild
    * @property-read int $childElementCount
    */
-  interface ParentNode extends QuerySelector {
+  interface ParentNode extends Node, QuerySelector {
 
     public function prepend($nodes);
 

--- a/src/FluentDOM/DOM/ProcessingInstruction.php
+++ b/src/FluentDOM/DOM/ProcessingInstruction.php
@@ -17,7 +17,7 @@ namespace FluentDOM\DOM {
    */
   class ProcessingInstruction
     extends \DOMProcessingInstruction
-    implements Node, Node\ChildNode, Node\NonDocumentTypeChildNode  {
+    implements Node\NonDocumentTypeChildNode  {
 
     use Node\ChildNode\Implementation;
     use Node\NonDocumentTypeChildNode\Properties;

--- a/src/FluentDOM/DOM/Text.php
+++ b/src/FluentDOM/DOM/Text.php
@@ -17,7 +17,7 @@ namespace FluentDOM\DOM {
    */
   class Text
     extends \DOMText
-    implements Node, Node\ChildNode, Node\NonDocumentTypeChildNode {
+    implements Node\NonDocumentTypeChildNode {
 
     use Node\ChildNode\Implementation;
     use Node\NonDocumentTypeChildNode\Properties;


### PR DESCRIPTION
Having a bit of trouble with static analysis (PHPStan) as `ChildNode` etc do not inherit from `Node`, even though there aren't any cases where an implementation only implements one of them (and doesn't seem to make sense to do so?).

This adds inheritance to the interfaces.