### PR TITLE
Add Clark Notation to elements

### DIFF
--- a/src/FluentDOM/DOM/Element.php
+++ b/src/FluentDOM/DOM/Element.php
@@ -359,6 +359,19 @@ namespace FluentDOM\DOM {
       return parent::getElementsByTagName($localName);
     }
 
+    /**
+     * The 'Clark Notation' for the element.
+     *
+     * @see http://www.jclark.com/xml/xmlns.htm
+     */
+    public function clarkNotation() : string {
+      if (!$this->namespaceURI) {
+        return $this->tagName;
+      }
+
+      return sprintf('{%s}%s', $this->namespaceURI, $this->tagName);
+    }
+
     /***************************
      * Array Access Interface
      ***************************/

--- a/tests/FluentDOM/DOM/ElementTest.php
+++ b/tests/FluentDOM/DOM/ElementTest.php
@@ -1073,5 +1073,20 @@ namespace FluentDOM\DOM {
       $document->loadXML($xml);
       $this->assertSame($expected, $document->documentElement->childElementCount);
     }
+
+    /**
+     * @param string $expected
+     * @param string $xml
+     * @covers \FluentDOM\DOM\Element::clarkNotation
+     * @testWith
+     *   ["foo", "<foo/>"]
+     *   ["{http://example.com}foo", "<foo xmlns=\"http://example.com\"/>"]
+     *   ["{urn:example}foo", "<foo xmlns=\"urn:example\"/>"]
+     */
+    public function testClarkNotation(string $expected, string $xml) {
+      $document = new Document();
+      $document->loadXML($xml);
+      $this->assertSame($expected, $document->documentElement->clarkNotation());
+    }
   }
 }


### PR DESCRIPTION
Quite a common pattern for referencing the combination of namespace and element name.